### PR TITLE
feat: use Ninja instead make, bump CMake to 3.25

### DIFF
--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -56,11 +56,11 @@ runs:
     - name: Install build tools using apt
       run: |
         sudo apt-get update -y
-        sudo apt-get install cmake build-essential -y
+        sudo apt install cmake ninja-build python3 python3-venv -y
       shell: bash
       if: env.OS == 'ubuntu'
     - name: Install build tools using brew
-      run: brew install make cmake --formula
+      run: brew install cmake ninja python3 --formula
       shell: bash
       if: env.OS == 'macos'
 

--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -70,7 +70,7 @@ jobs:
             -DASAN=OFF \
             -DPYTHON=COMPILE \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            . -B ${{github.workspace}}/build
+            -S . -B ${{github.workspace}}/build
 
       - uses: ZedThree/clang-tidy-review@v0.19.0
         id: review

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build directories, libraries and binary files
 **/myeasylog.log
+.venv/
 build/
 cmake-build-debug/
 dist/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.25)
 if (POLICY CMP0167)
     # deprecated by definition, but we use old behaviour for find_package(Boost) to load CMake's FindBoost module
     # TODO: port project to "Modern CMake" https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1
@@ -17,6 +17,9 @@ option(BUILD_NATIVE "Build for host machine" ON)
 option(USE_LTO "Build using interprocedural optimization" OFF)
 option(GDB_DEBUG "Include debug information for use by GDB" OFF)
 set(SANITIZER "" CACHE STRING "Build with sanitizer, possible values: ADDRESS, UB")
+
+# Enable colored output for Ninja messages
+set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 set(PYTHON OFF CACHE STRING "Compile Python bindings")
 set_property(CACHE PYTHON PROPERTY STRINGS OFF COMPILE INSTALL)

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ The following instructions were tested on Ubuntu 20.04+ LTS and macOS Sonoma 14.
 Prior to cloning the repository and attempting to build the project, ensure that you have the following software:
 
 - GNU GCC, version 10+, LLVM Clang, version 16+, or Apple Clang, version 15+
-- CMake, version 3.15+
+- CMake, version 3.25+
 - Boost library built with compiler you're going to use (GCC or Clang), version 1.85.0+
 
 To use test datasets you will need:
@@ -264,13 +264,26 @@ Instructions for other supported compilers can be found in [Desbordante wiki](ht
 
 #### Ubuntu dependencies installation (GCC)
 
-Run the following commands:
+For Ubuntu versions earlier than 24.04, you need to add the Kitware APT repository to your system 
+by following their [official guide](https://apt.kitware.com) to install the latest version of CMake.
+
+Then run the following commands:
 ```sh 
-sudo apt install g++ cmake libboost-all-dev git-lfs python3
+sudo apt update && sudo apt upgrade
+sudo apt install g++ cmake ninja-build libboost-all-dev git-lfs python3 python3-venv
 export CXX=g++
 ```
 The last line sets g++ as CMake compiler in your terminal session.
-You can also add them to the end of `~/.profile` to set this by default in all sessions.
+You can also set it by default in all sessions: `echo 'export CXX=g++' >> ~/.profile`
+
+For Ubuntu 24.04 and above, you can skip to the build steps. For older versions the Ubuntu APT repository
+might not have a compatible version of Boost, so you'll need to install it manually:
+```sh
+wget https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
+tar xzvf boost_1_87_0.tar.gz
+cd boost_1_87_0 && ./bootstrap.sh
+sudo ./b2 install --prefix=/usr/
+```
 
 #### macOS dependencies installation (Apple Clang)
 
@@ -319,12 +332,12 @@ In order to build tests, pull the test datasets using the following command:
 ```
 then build the tests themselves:
 ```sh
-./build.sh -j$(nproc)
+./build.sh
 ```
 
 The Python module can be built by providing the `--pybind` switch:
 ```sh
-./build.sh --pybind -j$(nproc)
+./build.sh --pybind 
 ```
 
 See `./build.sh --help` for more available options.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Downloads](https://static.pepy.tech/badge/desbordante/month)](https://pepy.tech/project/desbordante)
 
 <p>
-   <img src="https://github.com/Mstrutov/Desbordante/assets/88928096/d687809b-5a3b-420e-a192-a1a2b6697b2a"/>
+   <img src="https://github.com/Desbordante/desbordante-core/assets/88928096/d687809b-5a3b-420e-a192-a1a2b6697b2a"/>
 </p>
 
 # General
@@ -304,9 +304,9 @@ You can also add them to the end of `~/.profile` to set this by default in all s
 Clone the repository, change the current directory to the project directory and run the following commands:
 
 ```bash
-./build.sh
-python3 -m venv venv
-source venv/bin/activate
+./build.sh --deps-only
+python3 -m venv .venv
+source .venv/bin/activate
 python3 -m pip install .
 ```
 
@@ -329,7 +329,7 @@ The Python module can be built by providing the `--pybind` switch:
 
 See `./build.sh --help` for more available options.
 
-The `./build.sh` script generates the following file structure in `/path/to/Desbordante/build/target`:
+The `./build.sh` script generates the following file structure in `/path/to/desbordante-core/build/target`:
 ```
 ├───input_data
 │   └───some-sample-csv\'s.csv
@@ -370,7 +370,7 @@ Error downloading object: datasets/datasets.zip (2085458): Smudge error: Error d
 ```
 delete the already cloned version, set `GIT_LFS_SKIP_SMUDGE=1` environment variable and clone the repo again:
 ```sh
-GIT_LFS_SKIP_SMUDGE=1 git clone git@github.com:Mstrutov/Desbordante.git
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/Desbordante/desbordante-core.git
 ```
 
 ### No type hints in IDE

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -1,5 +1,5 @@
 <p>
-   <img src="https://github.com/Mstrutov/Desbordante/assets/88928096/d687809b-5a3b-420e-a192-a1a2b6697b2a"/>
+   <img src="https://github.com/Desbordante/desbordante-core/assets/88928096/d687809b-5a3b-420e-a192-a1a2b6697b2a"/>
 </p>
 
 ---
@@ -250,9 +250,9 @@ Install all dependencies listed in [README.md](https://github.com/Desbordante/de
 Then, in the Desbordante directory (the same one that contains this file), execute:
 
 ```bash
-./build.sh
-python3 -m venv venv
-source venv/bin/activate
+./build.sh --deps-only
+python3 -m venv .venv
+source .venv/bin/activate
 python3 -m pip install .
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -9,10 +9,10 @@ Usage: ./build.sh [options]
 
 Possible options:
   -h,         --help                  Display help
+              --deps-only             Install dependencies only (don't build)
   -p,         --pybind                Compile python bindings
   -n,         --no-tests              Don't build tests
   -u,         --no-unpack             Don't unpack datasets
-  -j[N],      --jobs[=N]              Allow N jobs at once (default [=1])
   -d,         --debug                 Set debug build type
   -s[S],      --sanitizer[=S]         Build with sanitizer S (has effect only for debug build).
                                       Possible values of S: ADDRESS, UB.
@@ -26,6 +26,9 @@ EOF
 for i in "$@"
     do
     case $i in
+        --deps-only) # Install dependencies only (don't build)
+            DEPS_ONLY=true
+            ;;
         -p|--pybind) # Compile python bindings
             PYBIND=true
             ;;
@@ -35,13 +38,10 @@ for i in "$@"
         -u|--no-unpack) # Don't unpack datasets
             NO_UNPACK=true
             ;;
-        -j*|--jobs=*) # Allow N jobs at once
-            JOBS_OPTION=$i
-            ;;
         -d|--debug) # Set debug build type
             DEBUG_MODE=true
             ;;
-        # It's a nightmare, we should use getopts for args parsing or even use something else
+        # It is a nightmare, we should use getopts for args parsing or even use something else
         # instead of bash
         --sanitizer=*) # Build with sanitizer S, long option
             SANITIZER="${i#*=}"
@@ -90,6 +90,10 @@ else
   if [[ ! -d "googletest" ]] ; then
     git clone https://github.com/google/googletest/ --branch v1.14.0 --depth 1
   fi
+fi
+
+if [[ $DEPS_ONLY == true ]]; then
+  exit 0
 fi
 
 if [[ $NO_UNPACK == true ]]; then

--- a/build.sh
+++ b/build.sh
@@ -121,7 +121,5 @@ if [[ -n $SANITIZER ]]; then
 fi
 
 cd ..
-mkdir -p build
-cd build
 rm -f CMakeCache.txt
-cmake $PREFIX .. && make $JOBS_OPTION
+cmake -S . -B build $PREFIX -G Ninja && cmake --build build

--- a/pull_datasets.sh
+++ b/pull_datasets.sh
@@ -2,8 +2,8 @@ git lfs pull
 if [ $? -eq 0 ]; then
     echo "PULLED VIA GIT LFS"
 else
-    echo "FAILED TO PULL VIA GIT LFS, RETRIEVING FROM 'Desbordante-Data' REPOSITORY"
-    git clone https://github.com/Mstrutov/Desbordante-Data.git
-    mv Desbordante-Data/datasets.zip datasets/datasets.zip
-    rm -rf Desbordante-Data
+    echo "FAILED TO PULL VIA GIT LFS, RETRIEVING FROM 'desbordante-data' REPOSITORY"
+    git clone https://github.com/Desbordante/desbordante-data.git
+    mv desbordante-data/datasets.zip datasets/datasets.zip
+    rm -rf desbordante-data
 fi


### PR DESCRIPTION
Change build.sh script:
- use Ninja instead of make
- add option for install dependencies only

Set CMake min version to 3.25 due to using of
`SYSTEM` option in add_subdirectory()

Update README.md:
- update Ubuntu dependencies installation guide
- fix building steps

Fix some typos and outdated links